### PR TITLE
Removed FAB shape style

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,8 +20,6 @@
         <item name="shapeAppearanceSmallComponent">@style/cutSmallShapeAppearance</item>
         <item name="shapeAppearanceMediumComponent">@style/cutMediumShapeAppearance</item>
         <item name="shapeAppearanceLargeComponent">@style/cutLargeShapeAppearance</item>
-
-        <item name="floatingActionButtonStyle">@style/CutFloatingActionButtonStyle</item>
     </style>
 
     <style name="DarkTheme.Rounded">
@@ -34,13 +32,6 @@
         <item name="shapeAppearanceSmallComponent">@style/cutSmallShapeAppearance</item>
         <item name="shapeAppearanceMediumComponent">@style/cutMediumShapeAppearance</item>
         <item name="shapeAppearanceLargeComponent">@style/cutLargeShapeAppearance</item>
-
-        <item name="floatingActionButtonStyle">@style/CutFloatingActionButtonStyle</item>
-    </style>
-
-    <!--FIXME FABのShapeはライブラリで反映される?-->
-    <style name="CutFloatingActionButtonStyle" parent="Widget.MaterialComponents.FloatingActionButton">
-        <item name="shapeAppearanceOverlay">@style/CutFloatingActionButtonShapeAppearance</item>
     </style>
 
     <style name="CutFloatingActionButtonShapeAppearance" parent="ShapeAppearanceOverlay.MaterialComponents.FloatingActionButton">


### PR DESCRIPTION
## Overview  
- Removed unnecessary FAB shape style is supported in library.

## Screenshot  

| before | after |
| --- | --- |
| ![device-2019-02-04-121241](https://user-images.githubusercontent.com/13705006/52188436-34499400-2876-11e9-840a-3bdc23bbfe9b.png) |![device-2019-02-04-121158](https://user-images.githubusercontent.com/13705006/52188424-1f6d0080-2876-11e9-9d40-7e850a874938.png)|