### PR TITLE
Downgrade appcompat version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
                 stdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
         ]
         androidx = [
-                appcompat       : "androidx.appcompat:appcompat:1.3.0-alpha01",
+                appcompat       : "androidx.appcompat:appcompat:1.2.0-alpha02",
                 activity        : "androidx.activity:activity:1.2.0-alpha06",
                 fragment        : "androidx.fragment:fragment:1.3.0-alpha06",
                 ktx             : "androidx.core:core-ktx:1.4.0-alpha01",


### PR DESCRIPTION
## Overview
- Calls to `AppCompatDelegate.setDefaultNightMode()` don't work well on from 1.2.0-alpha03, so downgrade version.
- This issue will be fixed at 1.2.0-rc02.  

## Issue
- close #

## Link
- https://issuetracker.google.com/issues/158923881
- https://android.googlesource.com/platform/frameworks/support/+/45a1bc4a15b5b10d0635d79fb55df2aced5a2a4a

## Screenshot

|Before|After|
|:--:|:--:|
|  |  |