### PR TITLE
Updated AndroidX libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,16 +8,16 @@ buildscript {
                 stdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
         ]
         androidx = [
-                appcompat       : "androidx.appcompat:appcompat:1.2.0-alpha02",
-                activity        : "androidx.activity:activity:1.2.0-alpha06",
-                fragment        : "androidx.fragment:fragment:1.3.0-alpha06",
+                appcompat       : "androidx.appcompat:appcompat:1.2.0-rc02",
+                activity        : "androidx.activity:activity-ktx:1.2.0-alpha07",
+                fragment        : "androidx.fragment:fragment-ktx:1.3.0-alpha07",
                 ktx             : "androidx.core:core-ktx:1.4.0-alpha01",
-                recyclerview    : "androidx.recyclerview:recyclerview:1.2.0-alpha04",
+                recyclerview    : "androidx.recyclerview:recyclerview:1.2.0-alpha05",
                 constraintlayout: "androidx.constraintlayout:constraintlayout:2.0.0-beta8",
                 preference      : "androidx.preference:preference:1.1.1",
                 navigation      : [
-                        fragment: 'androidx.navigation:navigation-fragment-ktx:2.3.0-beta01',
-                        ui      : 'androidx.navigation:navigation-ui-ktx:2.3.0-beta01'
+                        fragment: 'androidx.navigation:navigation-fragment-ktx:2.3.0',
+                        ui      : 'androidx.navigation:navigation-ui-ktx:2.3.0'
                 ]
         ]
 


### PR DESCRIPTION
## Overview
- Updated AndroidX libraries.
- Use -ktx libraries.

## Issue
- close #

## Link
- https://developer.android.com/jetpack/androidx/versions/all-channel#july_22_2020

## Screenshot

|Before|After|
|:--:|:--:|
|  |  |