### PR TITLE
Updated Android Studio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0-beta03'
+        classpath 'com.android.tools.build:gradle:4.1.0-beta04'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.2'
     }


### PR DESCRIPTION
## Overview
- Bump up Android Studio(AGP) version to 4.1.0-beta02.   

## Issue
- close #

## Link
- https://androidstudio.googleblog.com/2020/07/android-studio-41-beta-4-available.html

## Screenshot

|Before|After|
|:--:|:--:|
|  |  |