### PR TITLE
Updated Android Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MaterialGallery-android  
 
-![Android Studio](https://img.shields.io/badge/Android%20Studio-4.1.0%20Beta4-green.svg)
+![Android Studio](https://img.shields.io/badge/Android%20Studio-4.1.0%20Beta5-green.svg)
 ![Kotlin](https://img.shields.io/badge/kotlin-1.3.72-yellow.svg)
 
 ## About  

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0-beta04'
+        classpath 'com.android.tools.build:gradle:4.1.0-beta05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.2'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 26 16:56:38 JST 2020
+#Fri Jul 24 11:30:42 JST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip


### PR DESCRIPTION
## Overview
- Bump up Android Studio (AGP) version to 4.1.0-beta5

## Issue
- close #

## Link
- https://androidstudio.googleblog.com/2020/07/android-studio-41-beta-5-available.html

## Screenshot

|Before|After|
|:--:|:--:|
|  |  |