### PR TITLE
Fixed crash CircularProgressIndicator

### DIFF
--- a/studies/base/src/main/res/layout/fragment_component_gallery.xml
+++ b/studies/base/src/main/res/layout/fragment_component_gallery.xml
@@ -152,11 +152,15 @@
                 android:layout_marginTop="32dp"
                 android:text="Progress indicator" />
 
+            <!--
+                Settings app:indicatorSize because workaround of throws an exception if indicatorSize is less than twice of the trackThickness
+            -->
             <com.google.android.material.progressindicator.CircularProgressIndicator
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:indeterminate="true" />
+                android:indeterminate="true"
+                app:indicatorSize="41dp" />
 
             <TextView
                 android:layout_width="wrap_content"


### PR DESCRIPTION
## Overview
- Crash CircularProgressIndicator because throws an exception indicatorSize is less than twice of the trackThickness.
- Even if trackThickness is 20dp and indicatorSize is 40dp, it crashes depending on the screen size of the terminal.　　  

## Issue
- close #

## Link
-

## Screenshot

|Before|After|
|:--:|:--:|
|  |  |