### PR TITLE
Added Navigation Rail example

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -28,22 +28,6 @@
       </value>
     </option>
     <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <XML>

--- a/app/src/main/java/com/numero/material_gallery/components/DesignComponent.kt
+++ b/app/src/main/java/com/numero/material_gallery/components/DesignComponent.kt
@@ -71,6 +71,10 @@ enum class DesignComponent(
             R.string.navigation_drawer
     ),
 
+    NAVIGATION_RAIL(
+        R.string.navigation_rail
+    ),
+
     PROGRESS_INDICATOR(
             R.string.progress_indicator
     ),

--- a/app/src/main/java/com/numero/material_gallery/components/list/ComponentListAdapter.kt
+++ b/app/src/main/java/com/numero/material_gallery/components/list/ComponentListAdapter.kt
@@ -62,6 +62,7 @@ class ComponentItemViewHolder(
             DesignComponent.MATERIAL_DIALOG -> R.string.material_dialog_transition_name
             DesignComponent.MODAL_BOTTOM_SHEET -> R.string.modal_bottom_sheet_transition_name
             DesignComponent.NAVIGATION_DRAWER -> R.string.navigation_drawer_transition_name
+            DesignComponent.NAVIGATION_RAIL -> R.string.navigation_rail_transition_name
             DesignComponent.PROGRESS_INDICATOR -> R.string.progress_indicator_transition_name
             DesignComponent.RADIO_BUTTON -> R.string.radio_button_transition_name
             DesignComponent.SLIDER -> R.string.slider_transition_name

--- a/app/src/main/java/com/numero/material_gallery/components/list/ComponentListFragment.kt
+++ b/app/src/main/java/com/numero/material_gallery/components/list/ComponentListFragment.kt
@@ -80,6 +80,7 @@ class ComponentListFragment : Fragment(R.layout.fragment_component_list) {
             DesignComponent.MATERIAL_DIALOG -> R.id.action_ComponentList_to_MaterialDialog
             DesignComponent.MODAL_BOTTOM_SHEET -> R.id.action_ComponentList_to_ModalBottomSheet
             DesignComponent.NAVIGATION_DRAWER -> R.id.action_ComponentList_to_NavigationDrawer
+            DesignComponent.NAVIGATION_RAIL -> R.id.action_ComponentList_to_NavigationRail
             DesignComponent.PROGRESS_INDICATOR -> R.id.action_ComponentList_to_ProgressIndicator
             DesignComponent.RADIO_BUTTON -> R.id.action_ComponentList_to_RadioButton
             DesignComponent.SLIDER -> R.id.action_ComponentList_to_Slider

--- a/app/src/main/java/com/numero/material_gallery/components/navigationrail/NavigationRailFragment.kt
+++ b/app/src/main/java/com/numero/material_gallery/components/navigationrail/NavigationRailFragment.kt
@@ -1,0 +1,66 @@
+package com.numero.material_gallery.components.navigationrail
+
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import androidx.navigation.fragment.findNavController
+import com.google.android.material.navigationrail.NavigationRailView
+import com.numero.material_gallery.R
+import com.numero.material_gallery.components.MaterialContainerTransformFragment
+import com.numero.material_gallery.databinding.FragmentNavigationRailBinding
+import dev.chrisbanes.insetter.applyInsetter
+
+class NavigationRailFragment :
+    MaterialContainerTransformFragment(R.layout.fragment_navigation_rail) {
+
+    private var _binding: FragmentNavigationRailBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentNavigationRailBinding.bind(view)
+
+        binding.labelVisibilityRadioGroup.setOnCheckedChangeListener { _, checkedId ->
+            binding.navigationRailView.labelVisibilityMode = when (checkedId) {
+                R.id.labelVisibilityAutoRadioButton -> NavigationRailView.LABEL_VISIBILITY_AUTO
+                R.id.labelVisibilitySelectedRadioButton -> NavigationRailView.LABEL_VISIBILITY_SELECTED
+                R.id.labelVisibilityLabeledRadioButton -> NavigationRailView.LABEL_VISIBILITY_LABELED
+                R.id.labelVisibilityUnlabeledRadioButton -> NavigationRailView.LABEL_VISIBILITY_UNLABELED
+                else -> throw Exception("Not defined id")
+            }
+        }
+
+        binding.rootLayout.applyInsetter {
+            type(navigationBars = true) {
+                padding()
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.menu_common, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_current_theme -> {
+                findNavController().navigate(R.id.action_show_ThemeInfoDialog)
+                true
+            }
+            else -> false
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_navigation_rail.xml
+++ b/app/src/main/res/layout/fragment_navigation_rail.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/rootLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="horizontal"
+    android:transitionName="@string/navigation_rail_transition_name">
+
+    <com.google.android.material.navigationrail.NavigationRailView
+        android:id="@+id/navigationRailView"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        app:headerLayout="@layout/navigation_rail_header"
+        app:menu="@menu/menu_navigation_rail" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="16dp">
+
+            <androidx.appcompat.widget.AppCompatTextView
+                android:id="@+id/labelVisibilityTextView"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="Label visibility mode"
+                android:textAppearance="?attr/textAppearanceSubtitle2"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <RadioGroup
+                android:id="@+id/labelVisibilityRadioGroup"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:checkedButton="@id/labelVisibilityAutoRadioButton"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/labelVisibilityTextView">
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/labelVisibilityAutoRadioButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="16dp"
+                    android:text="Auto"
+                    android:textSize="16sp"
+                    app:useMaterialThemeColors="true" />
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/labelVisibilitySelectedRadioButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="16dp"
+                    android:text="Selected"
+                    android:textSize="16sp"
+                    app:useMaterialThemeColors="true" />
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/labelVisibilityLabeledRadioButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="16dp"
+                    android:text="Labeled"
+                    android:textSize="16sp"
+                    app:useMaterialThemeColors="true" />
+
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/labelVisibilityUnlabeledRadioButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="16dp"
+                    android:text="Unlabeled"
+                    android:textSize="16sp"
+                    app:useMaterialThemeColors="true" />
+
+            </RadioGroup>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/navigation_rail_header.xml
+++ b/app/src/main/res/layout/navigation_rail_header.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.floatingactionbutton.FloatingActionButton xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:src="@drawable/ic_add" />

--- a/app/src/main/res/menu/menu_navigation_rail.xml
+++ b/app/src/main/res/menu/menu_navigation_rail.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/nav_camera"
+        android:icon="@drawable/ic_menu_camera"
+        android:title="Import" />
+    <item
+        android:id="@+id/nav_gallery"
+        android:icon="@drawable/ic_menu_gallery"
+        android:title="Gallery" />
+    <item
+        android:id="@+id/nav_slideshow"
+        android:icon="@drawable/ic_menu_slideshow"
+        android:title="Slideshow" />
+    <item
+        android:id="@+id/nav_manage"
+        android:icon="@drawable/ic_menu_manage"
+        android:title="Tools" />
+
+</menu>

--- a/app/src/main/res/navigation/nav_components.xml
+++ b/app/src/main/res/navigation/nav_components.xml
@@ -50,6 +50,9 @@
             android:id="@+id/action_ComponentList_to_NavigationDrawer"
             app:destination="@id/NavigationDrawerScreen" />
         <action
+            android:id="@+id/action_ComponentList_to_NavigationRail"
+            app:destination="@id/NavigationRailScreen" />
+        <action
             android:id="@+id/action_ComponentList_to_ProgressIndicator"
             app:destination="@id/ProgressIndicatorScreen" />
         <action
@@ -161,6 +164,12 @@
         android:name="com.numero.material_gallery.components.navigationdrawer.NavigationDrawerFragment"
         android:label="@string/navigation_drawer"
         tools:layout="@layout/fragment_navigation_drawer" />
+
+    <fragment
+        android:id="@+id/NavigationRailScreen"
+        android:name="com.numero.material_gallery.components.navigationrail.NavigationRailFragment"
+        android:label="@string/navigation_rail"
+        tools:layout="@layout/fragment_navigation_rail" />
 
     <fragment
         android:id="@+id/ProgressIndicatorScreen"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="material_dialog">Material Dialog</string>
     <string name="modal_bottom_sheet">Modal Bottom Sheet</string>
     <string name="navigation_drawer">Navigation Drawer</string>
+    <string name="navigation_rail">Navigation Rail</string>
     <string name="progress_indicator">Progress Indicator</string>
     <string name="radio_button">Radio Button</string>
     <string name="slider">Slider</string>

--- a/app/src/main/res/values/transition_names.xml
+++ b/app/src/main/res/values/transition_names.xml
@@ -15,6 +15,7 @@
     <string name="material_dialog_transition_name">material_dialog</string>
     <string name="modal_bottom_sheet_transition_name">modal_bottom_sheet</string>
     <string name="navigation_drawer_transition_name">navigation_drawer</string>
+    <string name="navigation_rail_transition_name">navigation_rail</string>
     <string name="progress_indicator_transition_name">progress_indicator</string>
     <string name="radio_button_transition_name">radio_button</string>
     <string name="slider_transition_name">slider</string>


### PR DESCRIPTION
## Overview
-  Added Navigation Rail example.

## Issue
- close #

## Link
- https://github.com/material-components/material-components-android/blob/master/docs/components/NavigationRail.md

## Screenshot

<img src="https://user-images.githubusercontent.com/13705006/114007838-a4139900-989c-11eb-898c-2d933c1c86ff.png" width="200px" />