### PR TITLE
Workaround of lint failure

### DIFF
--- a/components/build.gradle
+++ b/components/build.gradle
@@ -34,6 +34,11 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+
+    lintOptions {
+        // https://github.com/google/dagger/issues/2582
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Overview
- Lint error caused by Dagger.
- So disabled Lint errors in :component.

## Issue
- close #

## Link
-

## Screenshot

|Before|After|
|:--:|:--:|
|  |  |