### PR TITLE
Bump AGP version to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MaterialGallery-android  
 
-![Android Studio](https://img.shields.io/badge/Android%20Studio-Chipmunk%20RC1-green.svg)
+![Android Studio](https://img.shields.io/badge/Android%20Studio-Chipmunk-green.svg)
 
 ## About  
 Catalog application of Material Components.  

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,8 @@ plugins {
 }
 
 android {
+    namespace 'com.numero.material_gallery'
+
     compileSdkVersion versions.compileSdk
 
     defaultConfig {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.numero.material_gallery">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:name=".MaterialGalleryApplication"

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0-rc01'
+        classpath 'com.android.tools.build:gradle:7.2.0'
         classpath libs.kotlinPlugin
         classpath libs.hilt.plugin
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.5'

--- a/components/build.gradle
+++ b/components/build.gradle
@@ -4,6 +4,8 @@ plugins {
 }
 
 android {
+    namespace 'com.numero.material_gallery.components'
+
     compileSdkVersion versions.compileSdk
 
     defaultConfig {
@@ -35,8 +37,7 @@ android {
         jvmTarget = '1.8'
     }
 
-    lintOptions {
-        // https://github.com/google/dagger/issues/2582
+    lint {
         abortOnError false
     }
 }

--- a/components/src/main/AndroidManifest.xml
+++ b/components/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.numero.material_gallery.components">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,6 +6,8 @@ plugins {
 }
 
 android {
+    namespace 'com.numero.material_gallery.core'
+
     compileSdkVersion versions.compileSdk
 
     defaultConfig {

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.numero.material_gallery.core" />
+<manifest />

--- a/resource/build.gradle
+++ b/resource/build.gradle
@@ -4,6 +4,8 @@ plugins {
 }
 
 android {
+    namespace 'jp.numero.material_gallery.resource'
+
     compileSdkVersion versions.compileSdk
 
     defaultConfig {

--- a/resource/src/main/AndroidManifest.xml
+++ b/resource/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="jp.numero.material_gallery.resource">
+<manifest>
 
 </manifest>

--- a/studies/base/build.gradle
+++ b/studies/base/build.gradle
@@ -4,6 +4,8 @@ plugins {
 }
 
 android {
+    namespace 'com.numero.material_gallery.base'
+
     compileSdkVersion versions.compileSdk
 
     defaultConfig {

--- a/studies/base/src/main/AndroidManifest.xml
+++ b/studies/base/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.numero.material_gallery.base">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/studies/crane/build.gradle
+++ b/studies/crane/build.gradle
@@ -4,6 +4,8 @@ plugins {
 }
 
 android {
+    namespace 'com.numero.material_gallery.studies.crane'
+
     compileSdkVersion versions.compileSdk
 
     defaultConfig {

--- a/studies/crane/src/main/AndroidManifest.xml
+++ b/studies/crane/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.numero.material_gallery.studies.crane" />
+<manifest />

--- a/studies/materialcomponent/build.gradle
+++ b/studies/materialcomponent/build.gradle
@@ -4,6 +4,8 @@ plugins {
 }
 
 android {
+    namespace 'com.numero.material_gallery.studies.materialcomponent'
+
     compileSdkVersion versions.compileSdk
 
     defaultConfig {

--- a/studies/materialcomponent/src/main/AndroidManifest.xml
+++ b/studies/materialcomponent/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.numero.material_gallery.studies.materialcomponent" />
+<manifest />

--- a/studies/reply/build.gradle
+++ b/studies/reply/build.gradle
@@ -4,6 +4,8 @@ plugins {
 }
 
 android {
+    namespace 'com.numero.material_gallery.studies.reply'
+
     compileSdkVersion versions.compileSdk
 
     defaultConfig {

--- a/studies/reply/src/main/AndroidManifest.xml
+++ b/studies/reply/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.numero.material_gallery.studies.reply" />
+<manifest />

--- a/studies/shrine/build.gradle
+++ b/studies/shrine/build.gradle
@@ -4,6 +4,8 @@ plugins {
 }
 
 android {
+    namespace 'com.numero.material_gallery.studies.shrines'
+
     compileSdkVersion versions.compileSdk
 
     defaultConfig {

--- a/studies/shrine/src/main/AndroidManifest.xml
+++ b/studies/shrine/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.numero.material_gallery.studies.shrines" />
+<manifest />


### PR DESCRIPTION
## Overview
- Bump AGP version to 7.2.0.

## Issue
- close #

## Link
- https://android-developers.googleblog.com/2022/05/android-studio-chipmunk.html

## Screenshot

|Before|After|
|:--:|:--:|
|  |  |